### PR TITLE
Fix redirect path for thank you page

### DIFF
--- a/server.py
+++ b/server.py
@@ -42,6 +42,6 @@ def submit_form():
     if request.method == 'POST':
         data = request.form.to_dict()
         write_to_csv(data)
-        return redirect("thankyou.html")
+        return redirect("/thankyou.html")
     else:
         return "something went wrong"


### PR DESCRIPTION
## Summary
- ensure form submission redirects to top-level thank you page

## Testing
- `python -m py_compile server.py`
- `python - <<'PY'
from server import app
with app.test_client() as c:
    resp = c.post('/submit_form', data={'email':'a','subject':'b','message':'c'})
    print('status', resp.status_code)
    print('location', resp.headers.get('Location'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6896195a5b98832b91f1897d158dacbc